### PR TITLE
Change to Copy & AMI build steps

### DIFF
--- a/.drone-v1.yml
+++ b/.drone-v1.yml
@@ -229,8 +229,8 @@ steps:
     VAULT_TOKEN:
       from_secret: VAULT_TOKEN_PROD
   when:
-   #branch:
-   # - master
+   branch:
+    - master
    event:
     - push
   depends_on:
@@ -283,29 +283,12 @@ steps:
 
       echo "All snapshots for $AMI_ID are now available!"
   when:
-    event:
+   branch:
+    - master
+   event:
       - push
   depends_on:
     - retrieve_aws_secrets_prod
-
-#- name: packer-copy-prod
-#  pull: if-not-exists
-#  image: *copy-image
-#  commands:
-#  - source ./set_aws_secrets_prod.sh
-#  - export filters="--owner 093401982388 --filters "Name=name,Values=dq-ops-win-tab-dev-*""
-#  - export os="win2019"
-#  - export HOME=/home/packer
-#  - packer --version
-#  - cd /home/packer
-#  - ./build.sh
-#  when:
-#    branch:
-#    - master
-#    event:
-#    - push
-#  depends_on:
-#    - retrieve_aws_secrets_prod
 
 - name: renew-vault-tokens
   pull: if-not-exists


### PR DESCRIPTION
Refactoring of packer-copy-notprod and packer-copy-prod Steps
Changes:
- Removed the following steps from the drone.yaml file:
          packer-copy-notprod
          packer-copy-prod

New Approach:
- Build the AMI only once in the CI account.
- Reuse the built AMI across other environments: NOTPROD and PROD.
- Copy the AMI from the DQ AWS CI account into both NOTPROD and PROD accounts.
- Ensure associated EBS snapshots are copied along with the AMI.

Benefits:
- Eliminates redundant AMI builds in NOTPROD and PROD.
- Reduces build time and cost.
- Maintains consistency across environments.